### PR TITLE
fix: token filter — independent range bounds, age unit, categories, audit filters

### DIFF
--- a/src/modules/tokens/services/tokens.service.ts
+++ b/src/modules/tokens/services/tokens.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Between, FindOptionsOrder, FindOptionsOrderValue, FindOptionsWhere, ILike, In, Repository } from "typeorm";
+import { Between, FindOptionsOrder, FindOptionsOrderValue, FindOptionsWhere, ILike, In, LessThanOrEqual, MoreThanOrEqual, Repository } from "typeorm";
 import { Token } from "../entities/token.entity";
 import { OhlcCandle } from "../entities/ohlc-candle.entity";
 import { TokenResponseDto, TokenDetailsResponseDto, TokenMetadata } from "../dtos/token.response.dto";
@@ -324,48 +324,49 @@ export class TokensService {
         } as const;
         const column = SortByMap[sort_by as keyof typeof SortByMap];
         const whereConditions: FindOptionsWhere<Token> = { network: this.network };
+
+        // Treat 0 as "not set" — 0 is the default unset value from the filter form.
+        const rangeOp = (min: number | null | undefined, max: number | null | undefined) => {
+            const lo = min != null && min !== 0 ? min : null;
+            const hi = max != null && max !== 0 ? max : null;
+            if (lo !== null && hi !== null) return Between(lo, hi);
+            if (lo !== null) return MoreThanOrEqual(lo);
+            if (hi !== null) return LessThanOrEqual(hi);
+            return undefined;
+        };
+
         if (filter?.metrics) {
             const m = filter.metrics;
-
-            if (m.age_min_minutes != null && m.age_max_minutes != null) {
-                whereConditions.ageSeconds = Between(m.age_min_minutes, m.age_max_minutes);
-            }
-
-            if (m.liquidity_min != null && m.liquidity_max != null) {
-                whereConditions.liquidity = Between(m.liquidity_min, m.liquidity_max);
-            }
-
-            if (m.market_cap_min != null && m.market_cap_max != null) {
-                whereConditions.marketCap = Between(m.market_cap_min, m.market_cap_max);
-            }
-
-            if (m.volume_24h_min != null && m.volume_24h_max != null) {
-                whereConditions.volume24h = Between(m.volume_24h_min, m.volume_24h_max);
-            }
-
-            if (m.txns_24h_min != null && m.txns_24h_max != null) {
-                whereConditions.txns24hTotal = Between(m.txns_24h_min, m.txns_24h_max);
-            }
-
-            if (m.holders_min != null && m.holders_max != null) {
-                whereConditions.holdersCount = Between(m.holders_min, m.holders_max);
-            }
-
-            if (m.price_change_24h_min != null && m.price_change_24h_max != null) {
-                whereConditions.priceChange24h = Between(m.price_change_24h_min, m.price_change_24h_max);
-            }
+            whereConditions.ageSeconds = rangeOp(
+                m.age_min_minutes != null ? m.age_min_minutes * 60 : null,
+                m.age_max_minutes != null ? m.age_max_minutes * 60 : null
+            );
+            whereConditions.liquidity = rangeOp(m.liquidity_min, m.liquidity_max);
+            whereConditions.marketCap = rangeOp(m.market_cap_min, m.market_cap_max);
+            whereConditions.volume24h = rangeOp(m.volume_24h_min, m.volume_24h_max);
+            whereConditions.txns24hTotal = rangeOp(m.txns_24h_min, m.txns_24h_max);
+            whereConditions.holdersCount = rangeOp(m.holders_min, m.holders_max);
+            whereConditions.priceChange24h = rangeOp(m.price_change_24h_min, m.price_change_24h_max);
         }
+
         if (filter?.holder_filters) {
             const h = filter.holder_filters;
-
-            if (h.top_10_max_percent != null) {
-                whereConditions.top10Percent = Between(0, h.top_10_max_percent);
-            }
-
-            if (h.insider_max_percent != null) {
-                whereConditions.insiderPercent = Between(0, h.insider_max_percent);
-            }
+            if (h.top_10_max_percent != null) whereConditions.top10Percent = LessThanOrEqual(h.top_10_max_percent);
+            if (h.insider_max_percent != null) whereConditions.insiderPercent = LessThanOrEqual(h.insider_max_percent);
         }
+
+        if (filter?.audit_filters) {
+            const a = filter.audit_filters;
+            if (a.mint_authority_disabled) whereConditions.mintAuthorityDisabled = true;
+            if (a.freeze_authority_disabled) whereConditions.freezeAuthorityDisabled = true;
+            if (a.lp_burnt) whereConditions.lpBurnt = true;
+            if (a.has_social_links) whereConditions.hasSocialLinks = true;
+        }
+
+        if (filter?.categories?.length > 0) {
+            whereConditions.category = { slug: In(filter.categories) };
+        }
+
         const where = filter?.search_query
             ? [
                   { ...whereConditions, name: ILike(`%${filter.search_query}%`) },


### PR DESCRIPTION
- Replace paired Between() with independent MoreThanOrEqual/LessThanOrEqual so min-only or max-only filters work correctly
- Convert age_min/max_minutes to seconds before comparing with ageSeconds column
- Add category filter via category.slug relation lookup
- Add audit_filters handling (mintAuthority, freezeAuthority, lpBurnt, hasSocialLinks)
- Fix search_query combination: all filter conditions now correctly carry over into each name/symbol/address OR branch