### PR TITLE
fix: strip query params from Helius REST client base URL

### DIFF
--- a/src/infra/solana/helius.service.ts
+++ b/src/infra/solana/helius.service.ts
@@ -13,8 +13,10 @@ export class HeliusService extends BaseSolanaRpcService {
 
     constructor(rpcUrl: string, apiKey: string) {
         super(rpcUrl);
+        const restBaseUrl = new URL(rpcUrl);
+        restBaseUrl.search = "";
         this.apiClient = axios.create({
-            baseURL: rpcUrl,
+            baseURL: restBaseUrl.toString(),
             timeout: 10000,
             headers: {
                 "Content-Type": "application/json"


### PR DESCRIPTION
rpcUrl already includes the api-key query param, and axios also appends it via params, causing a duplicated query param in requests.