### PR TITLE
feat[SCRUM-337]: AI chat daily quota + SOL-paid credits system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ HELIUS_API_KEY=your_helius_api_key
 IF_PROGRAM_ID=4tsHWpfGh94M3gmDBYj96jquEpGbtyLYz4q87roAXbZU
 IF_AUTHORITY=HJnpCRqahd2Zunhx1VyY9d9Hj7UyLSNWQEavybJC3MSa
 
+# Billing — wallet address that receives SOL payments for paid credits
+MERCHANT_WALLET=11111111111111111111111111111111
+
 # Jupiter Configuration
 # Base URL for price / token list / limit-order endpoints
 JUPITER_API_URL=https://api.jup.ag

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,7 @@ import { JitoModule } from "./infra/jito/jito.module";
 import { AdminAnalyticsModule } from "./modules/admin-analytics/admin-analytics.module";
 import { StakingModule } from "./modules/staking/staking.module";
 import { EventsModule } from "./events/events.module";
+import { BillingModule } from "./modules/billing/billing.module";
 
 @Module({
     imports: [
@@ -70,7 +71,8 @@ import { EventsModule } from "./events/events.module";
         JitoModule,
         AdminAnalyticsModule,
         StakingModule,
-        EventsModule
+        EventsModule,
+        BillingModule
     ],
     controllers: [],
     providers: []

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -28,6 +28,10 @@ const configuration = () => ({
         ifAuthority: process.env.IF_AUTHORITY || "HJnpCRqahd2Zunhx1VyY9d9Hj7UyLSNWQEavybJC3MSa"
     },
 
+    billing: {
+        merchantWallet: process.env.MERCHANT_WALLET
+    },
+
     helius: {
         rpcUrl: process.env.HELIUS_RPC_URL,
         apiKey: process.env.HELIUS_API_KEY

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -51,6 +51,9 @@ export const validationSchema = Joi.object({
     HELIUS_RPC_URL: Joi.string().uri().required(),
     HELIUS_API_KEY: Joi.string().required(),
 
+    // Billing — wallet that receives SOL payments for paid credits; required, no safe default
+    MERCHANT_WALLET: Joi.string().required(),
+
     // JWT
     JWT_SECRET: Joi.string().required(),
     JWT_EXPIRES_IN: Joi.string().optional(),

--- a/src/database/entity-registry.ts
+++ b/src/database/entity-registry.ts
@@ -12,6 +12,9 @@ import { BotSubscription } from "../modules/bot/entities/bot-subscription.entity
 import { WalletAlert } from "../modules/watchlist/entities/wallet-alert.entity";
 import { WatchedWallet } from "../modules/watchlist/entities/watched-wallet.entity";
 import { Favorite } from "../modules/account/entities/favorite.entity";
+import { UserCredit } from "../modules/billing/entities/user-credit.entity";
+import { FeatureUsage } from "../modules/billing/entities/feature-usage.entity";
+import { PaymentOrder } from "../modules/billing/entities/payment-order.entity";
 
 export type AppEntity =
     | Token
@@ -27,7 +30,10 @@ export type AppEntity =
     | BotSubscription
     | WalletAlert
     | WatchedWallet
-    | Favorite;
+    | Favorite
+    | UserCredit
+    | FeatureUsage
+    | PaymentOrder;
 
 export const ENTITIES = [
     Token,
@@ -43,5 +49,8 @@ export const ENTITIES = [
     BotSubscription,
     WalletAlert,
     WatchedWallet,
-    Favorite
+    Favorite,
+    UserCredit,
+    FeatureUsage,
+    PaymentOrder
 ];

--- a/src/database/migrations/1783000000000-CreateBillingTables.ts
+++ b/src/database/migrations/1783000000000-CreateBillingTables.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateBillingTables1783000000000 implements MigrationInterface {
+    name = "CreateBillingTables1783000000000";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "user_credits" (
+                "userId" character varying NOT NULL,
+                "balance" integer NOT NULL DEFAULT 0,
+                "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+                CONSTRAINT "PK_user_credits_userId" PRIMARY KEY ("userId"),
+                CONSTRAINT "CHK_user_credits_balance_non_negative" CHECK ("balance" >= 0)
+            )
+        `);
+
+        await queryRunner.query(`
+            CREATE TABLE "feature_usage" (
+                "userId" character varying NOT NULL,
+                "usageDate" date NOT NULL,
+                "count" integer NOT NULL DEFAULT 0,
+                CONSTRAINT "PK_feature_usage_userId_usageDate" PRIMARY KEY ("userId", "usageDate")
+            )
+        `);
+
+        await queryRunner.query(`
+            CREATE TABLE "payment_orders" (
+                "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "userId" character varying NOT NULL,
+                "packageCode" character varying NOT NULL,
+                "credits" integer NOT NULL,
+                "amountLamports" bigint NOT NULL,
+                "network" character varying NOT NULL DEFAULT 'mainnet',
+                "status" character varying NOT NULL DEFAULT 'pending',
+                "txSignature" character varying,
+                "memo" character varying NOT NULL,
+                "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+                "expiresAt" TIMESTAMP NOT NULL,
+                "completedAt" TIMESTAMP,
+                CONSTRAINT "PK_payment_orders_id" PRIMARY KEY ("id"),
+                CONSTRAINT "UQ_payment_orders_txSignature" UNIQUE ("txSignature")
+            )
+        `);
+        await queryRunner.query(`CREATE INDEX "IDX_payment_orders_status_expiresAt" ON "payment_orders" ("status", "expiresAt")`);
+        await queryRunner.query(`CREATE INDEX "IDX_payment_orders_userId_createdAt" ON "payment_orders" ("userId", "createdAt")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_payment_orders_userId_createdAt"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_payment_orders_status_expiresAt"`);
+        await queryRunner.query(`DROP TABLE "payment_orders"`);
+        await queryRunner.query(`DROP TABLE "feature_usage"`);
+        await queryRunner.query(`DROP TABLE "user_credits"`);
+    }
+}

--- a/src/modules/billing/billing.module.ts
+++ b/src/modules/billing/billing.module.ts
@@ -1,0 +1,21 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { SolanaModule } from "../../infra/solana/solana.module";
+import { RedisModule } from "../../redis/redis.module";
+import { UserCredit } from "./entities/user-credit.entity";
+import { FeatureUsage } from "./entities/feature-usage.entity";
+import { PaymentOrder } from "./entities/payment-order.entity";
+import { QuotaController } from "./controllers/quota.controller";
+import { QuotaService } from "./services/quota.service";
+import { PaymentController } from "./controllers/payment.controller";
+import { PaymentService } from "./services/payment.service";
+import { PaymentReconcileService } from "./services/payment-reconcile.service";
+
+@Module({
+    imports: [TypeOrmModule.forFeature([UserCredit, FeatureUsage, PaymentOrder]), ConfigModule, SolanaModule, RedisModule],
+    controllers: [QuotaController, PaymentController],
+    providers: [QuotaService, PaymentService, PaymentReconcileService],
+    exports: [QuotaService, PaymentService]
+})
+export class BillingModule {}

--- a/src/modules/billing/constants/memo.constant.ts
+++ b/src/modules/billing/constants/memo.constant.ts
@@ -1,0 +1,19 @@
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+
+export const MEMO_PROGRAM_ID = new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+
+export function memoInstruction(text: string): TransactionInstruction {
+    return new TransactionInstruction({
+        keys: [],
+        programId: MEMO_PROGRAM_ID,
+        data: Buffer.from(text, "utf8")
+    });
+}
+
+export function buildOrderMemo(orderId: string): string {
+    return `PAY:${orderId}`;
+}
+
+export function parseOrderIdFromMemo(memo: string): string | null {
+    return memo.startsWith("PAY:") ? memo.slice(4) : null;
+}

--- a/src/modules/billing/constants/packages.constant.ts
+++ b/src/modules/billing/constants/packages.constant.ts
@@ -1,0 +1,16 @@
+export interface PaymentPackage {
+    code: string;
+    credits: number;
+    lamports: bigint;
+}
+
+// Giá cố định theo SOL (chưa neo USD) — xem "còn mở" trong plan gốc.
+export const PACKAGES: Record<string, PaymentPackage> = {
+    credits_50: { code: "credits_50", credits: 50, lamports: 50_000_000n },
+    credits_120: { code: "credits_120", credits: 120, lamports: 100_000_000n }
+};
+
+export const PACKAGE_CODES = Object.keys(PACKAGES);
+
+export const ORDER_EXPIRY_MINUTES = 30;
+export const ORDER_RATE_LIMIT_PER_HOUR = 10;

--- a/src/modules/billing/controllers/payment.controller.ts
+++ b/src/modules/billing/controllers/payment.controller.ts
@@ -1,0 +1,49 @@
+import { Body, Controller, Get, Param, Post, Query, UseGuards } from "@nestjs/common";
+import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
+import { RequestCluster } from "../../../common/cluster/request-cluster.decorator";
+import type { Cluster } from "../../../common/cluster/cluster.types";
+import { CurrentUser, CurrentUserPayload } from "../../../common/decorators/current-user.decorator";
+import { PaymentService } from "../services/payment.service";
+import { CreateOrderDto } from "../dtos/create-order.dto";
+import { RefreshPaymentTransactionDto } from "../dtos/refresh-payment-transaction.dto";
+import { SubmitPaymentDto } from "../dtos/submit-payment.dto";
+import { PACKAGES } from "../constants/packages.constant";
+
+@Controller("billing/payment")
+export class PaymentController {
+    constructor(private readonly paymentService: PaymentService) {}
+
+    @Get("packages")
+    getPackages() {
+        return Object.values(PACKAGES).map(({ code, credits, lamports }) => ({ code, credits, lamports: lamports.toString() }));
+    }
+
+    @Post("orders")
+    @UseGuards(JwtAuthGuard)
+    async createOrder(@CurrentUser() user: CurrentUserPayload, @RequestCluster() cluster: Cluster, @Body() dto: CreateOrderDto) {
+        return this.paymentService.createOrder(user.id, cluster, dto);
+    }
+
+    @Post("orders/:id/refresh-tx")
+    @UseGuards(JwtAuthGuard)
+    async refreshTransaction(
+        @CurrentUser() user: CurrentUserPayload,
+        @RequestCluster() cluster: Cluster,
+        @Param("id") id: string,
+        @Body() dto: RefreshPaymentTransactionDto
+    ) {
+        return this.paymentService.refreshTransaction(user.id, cluster, id, dto.walletAddress);
+    }
+
+    @Post("orders/:id/submit")
+    @UseGuards(JwtAuthGuard)
+    async submitPayment(@CurrentUser() user: CurrentUserPayload, @RequestCluster() cluster: Cluster, @Param("id") id: string, @Body() dto: SubmitPaymentDto) {
+        return this.paymentService.submitPayment(user.id, cluster, id, dto);
+    }
+
+    @Get("orders")
+    @UseGuards(JwtAuthGuard)
+    async listOrders(@CurrentUser() user: CurrentUserPayload, @Query("page") page?: string, @Query("limit") limit?: string) {
+        return this.paymentService.listOrders(user.id, page ? parseInt(page, 10) : undefined, limit ? parseInt(limit, 10) : undefined);
+    }
+}

--- a/src/modules/billing/controllers/payment.controller.ts
+++ b/src/modules/billing/controllers/payment.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Query, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, Param, Post, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
 import { RequestCluster } from "../../../common/cluster/request-cluster.decorator";
 import type { Cluster } from "../../../common/cluster/cluster.types";
@@ -39,11 +39,5 @@ export class PaymentController {
     @UseGuards(JwtAuthGuard)
     async submitPayment(@CurrentUser() user: CurrentUserPayload, @RequestCluster() cluster: Cluster, @Param("id") id: string, @Body() dto: SubmitPaymentDto) {
         return this.paymentService.submitPayment(user.id, cluster, id, dto);
-    }
-
-    @Get("orders")
-    @UseGuards(JwtAuthGuard)
-    async listOrders(@CurrentUser() user: CurrentUserPayload, @Query("page") page?: string, @Query("limit") limit?: string) {
-        return this.paymentService.listOrders(user.id, page ? parseInt(page, 10) : undefined, limit ? parseInt(limit, 10) : undefined);
     }
 }

--- a/src/modules/billing/controllers/quota.controller.ts
+++ b/src/modules/billing/controllers/quota.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
+import { CurrentUser, CurrentUserPayload } from "../../../common/decorators/current-user.decorator";
+import { QuotaService } from "../services/quota.service";
+
+@Controller("billing")
+@UseGuards(JwtAuthGuard)
+export class QuotaController {
+    constructor(private readonly quotaService: QuotaService) {}
+
+    @Get("quota")
+    async getQuota(@CurrentUser() user: CurrentUserPayload) {
+        return this.quotaService.getQuotaStatus(user.id);
+    }
+}

--- a/src/modules/billing/dtos/create-order.dto.ts
+++ b/src/modules/billing/dtos/create-order.dto.ts
@@ -1,0 +1,11 @@
+import { IsIn } from "class-validator";
+import { IsSolanaAddress } from "../../../common/validators/is-solana-address.validator";
+import { PACKAGE_CODES } from "../constants/packages.constant";
+
+export class CreateOrderDto {
+    @IsIn(PACKAGE_CODES)
+    packageCode: string;
+
+    @IsSolanaAddress()
+    walletAddress: string;
+}

--- a/src/modules/billing/dtos/refresh-payment-transaction.dto.ts
+++ b/src/modules/billing/dtos/refresh-payment-transaction.dto.ts
@@ -1,0 +1,6 @@
+import { IsSolanaAddress } from "../../../common/validators/is-solana-address.validator";
+
+export class RefreshPaymentTransactionDto {
+    @IsSolanaAddress()
+    walletAddress: string;
+}

--- a/src/modules/billing/dtos/submit-payment.dto.ts
+++ b/src/modules/billing/dtos/submit-payment.dto.ts
@@ -1,0 +1,7 @@
+import { IsBase64, IsString } from "class-validator";
+
+export class SubmitPaymentDto {
+    @IsBase64()
+    @IsString()
+    signedTransaction: string;
+}

--- a/src/modules/billing/entities/feature-usage.entity.ts
+++ b/src/modules/billing/entities/feature-usage.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryColumn, Column } from "typeorm";
+
+@Entity("feature_usage")
+export class FeatureUsage {
+    @PrimaryColumn({ type: "varchar" })
+    userId: string;
+
+    @PrimaryColumn({ type: "date" })
+    usageDate: string;
+
+    @Column({ type: "int", default: 0 })
+    count: number;
+}

--- a/src/modules/billing/entities/payment-order.entity.ts
+++ b/src/modules/billing/entities/payment-order.entity.ts
@@ -1,0 +1,50 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from "typeorm";
+import type { Cluster } from "../../../common/cluster/cluster.types";
+
+export enum PaymentOrderStatus {
+    PENDING = "pending",
+    COMPLETED = "completed",
+    EXPIRED = "expired",
+    FAILED = "failed"
+}
+
+@Entity("payment_orders")
+@Index(["status", "expiresAt"])
+@Index(["userId", "createdAt"])
+export class PaymentOrder {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+
+    @Column({ type: "varchar" })
+    userId: string;
+
+    @Column({ type: "varchar" })
+    packageCode: string;
+
+    @Column({ type: "int" })
+    credits: number;
+
+    @Column({ type: "bigint" })
+    amountLamports: string;
+
+    @Column({ type: "varchar", default: "mainnet" })
+    network: Cluster;
+
+    @Column({ type: "varchar", default: PaymentOrderStatus.PENDING })
+    status: PaymentOrderStatus;
+
+    @Column({ type: "varchar", unique: true, nullable: true })
+    txSignature: string | null;
+
+    @Column({ type: "varchar" })
+    memo: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @Column({ type: "timestamp" })
+    expiresAt: Date;
+
+    @Column({ type: "timestamp", nullable: true })
+    completedAt: Date | null;
+}

--- a/src/modules/billing/entities/user-credit.entity.ts
+++ b/src/modules/billing/entities/user-credit.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryColumn, Column, UpdateDateColumn } from "typeorm";
+
+@Entity("user_credits")
+export class UserCredit {
+    @PrimaryColumn({ type: "varchar" })
+    userId: string;
+
+    @Column({ type: "int", default: 0 })
+    balance: number;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/src/modules/billing/exceptions/quota-exceeded.exception.ts
+++ b/src/modules/billing/exceptions/quota-exceeded.exception.ts
@@ -1,0 +1,11 @@
+import { ForbiddenException } from "@nestjs/common";
+
+export class QuotaExceededException extends ForbiddenException {
+    constructor() {
+        super({
+            message: "Daily quota exceeded",
+            error: "QuotaExceeded",
+            canPurchase: true
+        });
+    }
+}

--- a/src/modules/billing/services/payment-reconcile.service.ts
+++ b/src/modules/billing/services/payment-reconcile.service.ts
@@ -1,0 +1,113 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Cron } from "@nestjs/schedule";
+import { ConfigService } from "@nestjs/config";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { ConfirmedSignatureInfo, PublicKey } from "@solana/web3.js";
+import { CLUSTERS, Cluster } from "../../../common/cluster/cluster.types";
+import { HeliusResolver } from "../../../infra/solana/helius.resolver";
+import { HeliusService } from "../../../infra/solana/helius.service";
+import { RedisService } from "../../../redis/services/redis.service";
+import { PaymentOrder, PaymentOrderStatus } from "../entities/payment-order.entity";
+import { PaymentService } from "./payment.service";
+import { extractIncomingTransfer } from "./payment-tx-parser.util";
+
+const SCAN_LIMIT = 100;
+
+// Lưới an toàn cho trường hợp SolanaService.submitAndConfirm đã thành công on-chain
+// nhưng process crash TRƯỚC KHI PaymentService.completeOrder commit — quét ví
+// merchant định kỳ, khớp theo memo "PAY:{orderId}", tự hoàn tất order nếu tìm thấy.
+// completeOrder() dùng chung với submitPayment() nên dù ai thắng race cũng không
+// double-credit (điều kiện WHERE status='pending' trong cùng 1 câu UPDATE).
+@Injectable()
+export class PaymentReconcileService {
+    private readonly logger = new Logger(PaymentReconcileService.name);
+
+    constructor(
+        private readonly heliusResolver: HeliusResolver,
+        private readonly redisService: RedisService,
+        private readonly configService: ConfigService,
+        private readonly paymentService: PaymentService,
+        @InjectRepository(PaymentOrder)
+        private readonly paymentOrderRepository: Repository<PaymentOrder>
+    ) {}
+
+    @Cron("*/2 * * * *")
+    async reconcile(): Promise<void> {
+        const merchantWallet = this.getMerchantWallet();
+        if (!merchantWallet) return;
+
+        for (const cluster of CLUSTERS) {
+            await this.reconcileCluster(cluster, merchantWallet);
+        }
+
+        await this.expirePendingOrders();
+    }
+
+    private async reconcileCluster(cluster: Cluster, merchantWallet: PublicKey): Promise<void> {
+        const rpc = this.heliusResolver.forCluster(cluster);
+        const cursorKey = RedisService.KEYS.BILLING_RECONCILE_CURSOR(cluster);
+        const cursor = await this.redisService.get<string>(cursorKey);
+
+        let signatures: ConfirmedSignatureInfo[];
+        try {
+            signatures = await rpc.getSignaturesForAddress(merchantWallet, { until: cursor ?? undefined, limit: SCAN_LIMIT });
+        } catch (error) {
+            this.logger.error(`Failed to fetch signatures for ${cluster}: ${(error as Error).message}`);
+            return;
+        }
+
+        if (signatures.length === 0) return;
+
+        // getSignaturesForAddress trả về mới nhất trước — xử lý theo thứ tự cũ → mới.
+        for (const { signature } of [...signatures].reverse()) {
+            await this.reconcileSignature(cluster, signature, merchantWallet, rpc);
+        }
+
+        await this.redisService.set(cursorKey, signatures[0].signature);
+    }
+
+    private async reconcileSignature(cluster: Cluster, signature: string, merchantWallet: PublicKey, rpc: HeliusService): Promise<void> {
+        const alreadyRecorded = await this.paymentOrderRepository.count({ where: { txSignature: signature } });
+        if (alreadyRecorded > 0) return;
+
+        const tx = await rpc.getParsedTransaction(signature, { maxSupportedTransactionVersion: 0 });
+        if (!tx || tx.meta?.err) return;
+
+        const { orderId, rawMemo, source, lamports } = extractIncomingTransfer(tx, merchantWallet);
+        if (lamports === null) return; // không phải transfer tới merchantWallet, không có gì để ghi nhận
+
+        const order = orderId ? await this.paymentOrderRepository.findOne({ where: { id: orderId, network: cluster } }) : null;
+        const isValidPayment =
+            !!order && (order.status === PaymentOrderStatus.PENDING || order.status === PaymentOrderStatus.EXPIRED) && lamports >= BigInt(order.amountLamports);
+
+        if (isValidPayment && order) {
+            this.logger.log(`Reconciled payment for order=${order.id} signature=${signature} cluster=${cluster}`);
+            await this.paymentService.completeOrder(order.id, signature);
+            return;
+        }
+
+        // Không khớp được order nào — log để tra cứu thủ công, không còn lưu bảng riêng.
+        this.logger.warn(
+            `Unmatched transfer signature=${signature} cluster=${cluster} from=${source ?? "unknown"} lamports=${lamports} memo=${rawMemo ?? "none"}`
+        );
+    }
+
+    private async expirePendingOrders(): Promise<void> {
+        await this.paymentOrderRepository.query(`UPDATE payment_orders SET "status" = $1 WHERE "status" = $2 AND "expiresAt" < NOW()`, [
+            PaymentOrderStatus.EXPIRED,
+            PaymentOrderStatus.PENDING
+        ]);
+    }
+
+    private getMerchantWallet(): PublicKey | null {
+        const value = this.configService.get<string>("billing.merchantWallet");
+        if (!value) return null;
+        try {
+            return new PublicKey(value);
+        } catch {
+            this.logger.error("MERCHANT_WALLET is not a valid public key, skipping reconciliation.");
+            return null;
+        }
+    }
+}

--- a/src/modules/billing/services/payment-tx-parser.util.ts
+++ b/src/modules/billing/services/payment-tx-parser.util.ts
@@ -1,0 +1,57 @@
+import { PublicKey } from "@solana/web3.js";
+import type { ParsedInstruction, ParsedTransactionWithMeta, PartiallyDecodedInstruction } from "@solana/web3.js";
+import bs58 from "bs58";
+import { MEMO_PROGRAM_ID, parseOrderIdFromMemo } from "../constants/memo.constant";
+
+export interface ParsedIncomingTransfer {
+    orderId: string | null;
+    rawMemo: string | null;
+    source: string | null;
+    lamports: bigint | null;
+}
+
+interface ParsedSystemTransferInfo {
+    type: string;
+    info: { destination: string; lamports: number; source: string };
+}
+
+function isParsedInstruction(ix: ParsedInstruction | PartiallyDecodedInstruction): ix is ParsedInstruction {
+    return "parsed" in ix;
+}
+
+// Đọc transaction đã confirm trên chain, tìm system-transfer TỚI merchantWallet
+// và memo "PAY:{orderId}" đi kèm — dùng bởi cron đối soát để verify độc lập các
+// giao dịch mà app không tự submit (không được bảo đảm cấu trúc như flow submit chính).
+export function extractIncomingTransfer(tx: ParsedTransactionWithMeta, merchantWallet: PublicKey): ParsedIncomingTransfer {
+    const instructions = tx.transaction.message.instructions;
+    const merchantAddress = merchantWallet.toBase58();
+
+    let source: string | null = null;
+    let lamports: bigint | null = null;
+    for (const ix of instructions) {
+        if (isParsedInstruction(ix) && ix.program === "system") {
+            const parsed = ix.parsed as ParsedSystemTransferInfo;
+            if (parsed.type === "transfer" && parsed.info.destination === merchantAddress) {
+                source = parsed.info.source;
+                lamports = BigInt(parsed.info.lamports);
+                break;
+            }
+        }
+    }
+
+    let rawMemo: string | null = null;
+    for (const ix of instructions) {
+        if (!isParsedInstruction(ix) && ix.programId.equals(MEMO_PROGRAM_ID)) {
+            try {
+                rawMemo = Buffer.from(bs58.decode(ix.data)).toString("utf8");
+            } catch {
+                rawMemo = null;
+            }
+            if (rawMemo) break;
+        }
+    }
+
+    const orderId = rawMemo ? parseOrderIdFromMemo(rawMemo) : null;
+
+    return { orderId, rawMemo, source, lamports };
+}

--- a/src/modules/billing/services/payment.service.ts
+++ b/src/modules/billing/services/payment.service.ts
@@ -12,7 +12,7 @@ import { CreateOrderDto } from "../dtos/create-order.dto";
 import { SubmitPaymentDto } from "../dtos/submit-payment.dto";
 import { buildOrderMemo, memoInstruction } from "../constants/memo.constant";
 import { ORDER_EXPIRY_MINUTES, ORDER_RATE_LIMIT_PER_HOUR, PACKAGES } from "../constants/packages.constant";
-import { BuiltPaymentTransaction, CompleteOrderResult, CreatedPaymentOrder, PaymentOrderPage, SubmitPaymentResult } from "../types/billing.types";
+import { BuiltPaymentTransaction, CompleteOrderResult, CreatedPaymentOrder, SubmitPaymentResult } from "../types/billing.types";
 
 @Injectable()
 export class PaymentService {
@@ -110,33 +110,6 @@ export class PaymentService {
 
             return { alreadyProcessed: false, credits };
         });
-    }
-
-    async listOrders(userId: string, page = 1, limit = 20): Promise<PaymentOrderPage> {
-        const [orders, total] = await this.paymentOrderRepository.findAndCount({
-            where: { userId },
-            order: { createdAt: "DESC" },
-            take: limit,
-            skip: (page - 1) * limit
-        });
-
-        return {
-            orders: orders.map((order) => ({
-                id: order.id,
-                packageCode: order.packageCode,
-                credits: order.credits,
-                amountLamports: order.amountLamports,
-                network: order.network,
-                status: order.status,
-                txSignature: order.txSignature,
-                createdAt: order.createdAt.toISOString(),
-                expiresAt: order.expiresAt.toISOString(),
-                completedAt: order.completedAt?.toISOString() ?? null
-            })),
-            total,
-            page,
-            limit
-        };
     }
 
     private async buildPaymentTransaction(cluster: Cluster, walletAddress: string, lamports: bigint, memo: string): Promise<BuiltPaymentTransaction> {

--- a/src/modules/billing/services/payment.service.ts
+++ b/src/modules/billing/services/payment.service.ts
@@ -1,0 +1,213 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { InjectDataSource, InjectRepository } from "@nestjs/typeorm";
+import { DataSource, Repository } from "typeorm";
+import { PublicKey, SystemProgram, TransactionMessage, VersionedTransaction } from "@solana/web3.js";
+import type { Cluster } from "../../../common/cluster/cluster.types";
+import { HeliusResolver } from "../../../infra/solana/helius.resolver";
+import { SolanaService } from "../../../infra/solana/solana.service";
+import { RedisService } from "../../../redis/services/redis.service";
+import { PaymentOrder, PaymentOrderStatus } from "../entities/payment-order.entity";
+import { CreateOrderDto } from "../dtos/create-order.dto";
+import { SubmitPaymentDto } from "../dtos/submit-payment.dto";
+import { buildOrderMemo, memoInstruction } from "../constants/memo.constant";
+import { ORDER_EXPIRY_MINUTES, ORDER_RATE_LIMIT_PER_HOUR, PACKAGES } from "../constants/packages.constant";
+import { BuiltPaymentTransaction, CompleteOrderResult, CreatedPaymentOrder, PaymentOrderPage, SubmitPaymentResult } from "../types/billing.types";
+
+@Injectable()
+export class PaymentService {
+    constructor(
+        @InjectRepository(PaymentOrder)
+        private readonly paymentOrderRepository: Repository<PaymentOrder>,
+        @InjectDataSource()
+        private readonly dataSource: DataSource,
+        private readonly heliusResolver: HeliusResolver,
+        private readonly solanaService: SolanaService,
+        private readonly redisService: RedisService,
+        private readonly configService: ConfigService
+    ) {}
+
+    async createOrder(userId: string, cluster: Cluster, dto: CreateOrderDto): Promise<CreatedPaymentOrder> {
+        const pkg = PACKAGES[dto.packageCode];
+        if (!pkg) {
+            throw new BadRequestException("Invalid package code.");
+        }
+
+        await this.assertOrderRateLimitNotExceeded(userId);
+
+        const order = await this.paymentOrderRepository.save(
+            this.paymentOrderRepository.create({
+                userId,
+                packageCode: pkg.code,
+                credits: pkg.credits,
+                amountLamports: pkg.lamports.toString(),
+                network: cluster,
+                memo: "PAY:pending",
+                expiresAt: new Date(Date.now() + ORDER_EXPIRY_MINUTES * 60 * 1000)
+            })
+        );
+        const memo = buildOrderMemo(order.id);
+        await this.paymentOrderRepository.update(order.id, { memo });
+
+        const built = await this.buildPaymentTransaction(cluster, dto.walletAddress, pkg.lamports, memo);
+
+        return {
+            orderId: order.id,
+            packageCode: pkg.code,
+            credits: pkg.credits,
+            amountLamports: pkg.lamports.toString(),
+            expiresAt: order.expiresAt.toISOString(),
+            ...built
+        };
+    }
+
+    async refreshTransaction(userId: string, cluster: Cluster, orderId: string, walletAddress: string): Promise<BuiltPaymentTransaction> {
+        const order = await this.getOwnedPendingOrder(userId, orderId);
+        return this.buildPaymentTransaction(cluster, walletAddress, BigInt(order.amountLamports), order.memo);
+    }
+
+    async submitPayment(userId: string, cluster: Cluster, orderId: string, dto: SubmitPaymentDto): Promise<SubmitPaymentResult> {
+        const order = await this.getOwnedOrder(userId, orderId);
+
+        if (order.status === PaymentOrderStatus.COMPLETED) {
+            return { success: true, creditsAdded: order.credits, alreadyProcessed: true };
+        }
+        if (order.status !== PaymentOrderStatus.PENDING) {
+            throw new BadRequestException(`Order is ${order.status}, cannot submit payment.`);
+        }
+
+        const { signature } = await this.solanaService.submitAndConfirm(cluster, dto.signedTransaction);
+        const result = await this.completeOrder(order.id, signature);
+
+        return { success: true, creditsAdded: result.credits ?? order.credits, alreadyProcessed: result.alreadyProcessed };
+    }
+
+    // Dùng chung bởi submitPayment() (đã tự submit+confirm tx nên tin tưởng signature
+    // này) VÀ cron đối soát (đã verify amount/err/memo độc lập trước khi gọi tới đây).
+    // Đây là nơi DUY NHẤT ghi nhận thanh toán — điều kiện WHERE status='pending' đảm
+    // bảo dù ai thắng race cũng chỉ cộng credits đúng 1 lần.
+    async completeOrder(orderId: string, signature: string): Promise<CompleteOrderResult> {
+        return this.dataSource.transaction(async (manager) => {
+            // manager.query() trên UPDATE trả về tuple [rows, rowCount] chứ không phải rows
+            // trực tiếp (khác với INSERT) — phải destructure đúng, nếu không rows[0] chính
+            // là mảng rows lồng bên trong, khiến credits/userId đọc ra undefined.
+            const [rows] = await manager.query<[Array<{ credits: number; userId: string }>, number]>(
+                `UPDATE payment_orders SET "status" = $1, "txSignature" = $2, "completedAt" = NOW()
+                 WHERE "id" = $3 AND "status" = $4
+                 RETURNING "credits", "userId"`,
+                [PaymentOrderStatus.COMPLETED, signature, orderId, PaymentOrderStatus.PENDING]
+            );
+            if (rows.length === 0) {
+                return { alreadyProcessed: true };
+            }
+
+            const { credits, userId } = rows[0];
+            await manager.query(
+                `INSERT INTO user_credits ("userId", "balance") VALUES ($1, $2)
+                 ON CONFLICT ("userId") DO UPDATE SET "balance" = user_credits."balance" + $2, "updatedAt" = NOW()`,
+                [userId, credits]
+            );
+
+            return { alreadyProcessed: false, credits };
+        });
+    }
+
+    async listOrders(userId: string, page = 1, limit = 20): Promise<PaymentOrderPage> {
+        const [orders, total] = await this.paymentOrderRepository.findAndCount({
+            where: { userId },
+            order: { createdAt: "DESC" },
+            take: limit,
+            skip: (page - 1) * limit
+        });
+
+        return {
+            orders: orders.map((order) => ({
+                id: order.id,
+                packageCode: order.packageCode,
+                credits: order.credits,
+                amountLamports: order.amountLamports,
+                network: order.network,
+                status: order.status,
+                txSignature: order.txSignature,
+                createdAt: order.createdAt.toISOString(),
+                expiresAt: order.expiresAt.toISOString(),
+                completedAt: order.completedAt?.toISOString() ?? null
+            })),
+            total,
+            page,
+            limit
+        };
+    }
+
+    private async buildPaymentTransaction(cluster: Cluster, walletAddress: string, lamports: bigint, memo: string): Promise<BuiltPaymentTransaction> {
+        const owner = this.parsePublicKey(walletAddress);
+        const rpc = this.heliusResolver.forCluster(cluster);
+        const latestBlockhash = await rpc.getLatestBlockhash("confirmed");
+
+        const transferInstruction = SystemProgram.transfer({
+            fromPubkey: owner,
+            toPubkey: this.getMerchantWallet(),
+            lamports
+        });
+        const message = new TransactionMessage({
+            payerKey: owner,
+            recentBlockhash: latestBlockhash.blockhash,
+            instructions: [transferInstruction, memoInstruction(memo)]
+        }).compileToV0Message();
+        const tx = new VersionedTransaction(message);
+
+        return {
+            transaction: Buffer.from(tx.serialize()).toString("base64"),
+            blockhash: latestBlockhash.blockhash,
+            lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+        };
+    }
+
+    private async getOwnedOrder(userId: string, orderId: string): Promise<PaymentOrder> {
+        const order = await this.paymentOrderRepository.findOne({ where: { id: orderId, userId } });
+        if (!order) {
+            throw new NotFoundException("Order not found.");
+        }
+        return order;
+    }
+
+    private async getOwnedPendingOrder(userId: string, orderId: string): Promise<PaymentOrder> {
+        const order = await this.getOwnedOrder(userId, orderId);
+        if (order.status !== PaymentOrderStatus.PENDING) {
+            throw new BadRequestException(`Order is ${order.status}, cannot refresh.`);
+        }
+        if (order.expiresAt.getTime() < Date.now()) {
+            throw new BadRequestException("Order has expired.");
+        }
+        return order;
+    }
+
+    private async assertOrderRateLimitNotExceeded(userId: string): Promise<void> {
+        const key = RedisService.KEYS.BILLING_ORDER_RATE_LIMIT(userId);
+        const count = await this.redisService.incr(key);
+        if (count === 1) {
+            await this.redisService.expire(key, RedisService.TTL.BILLING_ORDER_RATE_LIMIT);
+        }
+        // count === null nghĩa là Redis không khả dụng — fail open, không chặn user
+        // thật vì lỗi hạ tầng (khớp với cách RedisService xuống cấp mềm ở nơi khác).
+        if (count !== null && count > ORDER_RATE_LIMIT_PER_HOUR) {
+            throw new BadRequestException("Too many payment orders created recently. Try again later.");
+        }
+    }
+
+    private getMerchantWallet(): PublicKey {
+        const value = this.configService.get<string>("billing.merchantWallet");
+        if (!value) {
+            throw new BadRequestException("MERCHANT_WALLET is not configured.");
+        }
+        return this.parsePublicKey(value);
+    }
+
+    private parsePublicKey(value: string): PublicKey {
+        try {
+            return new PublicKey(value);
+        } catch {
+            throw new BadRequestException("Invalid wallet address.");
+        }
+    }
+}

--- a/src/modules/billing/services/quota.service.spec.ts
+++ b/src/modules/billing/services/quota.service.spec.ts
@@ -1,0 +1,127 @@
+import type { Repository } from "typeorm";
+import { FeatureUsage } from "../entities/feature-usage.entity";
+import { UserCredit } from "../entities/user-credit.entity";
+import { FREE_DAILY_QUOTA_LIMIT, QuotaService } from "./quota.service";
+
+// Mock ".query()" mô phỏng đúng semantics atomic của câu SQL thật (check-and-mutate
+// trong 1 lần gọi, không có await ở giữa) — đây là điều Postgres đảm bảo qua row lock
+// khi nhiều request cùng UPSERT/UPDATE trên cùng key; test verify logic service đọc
+// đúng kết quả "có row / không có row" để enforce giới hạn, không test lock của Postgres.
+function createFeatureUsageRepositoryMock(initialCount = 0) {
+    const state = { count: initialCount, exists: initialCount > 0 };
+    const query = jest.fn((_sql: string, params: unknown[]) => {
+        const [, , amount, limit] = params as [string, string, number, number];
+        if (!state.exists) {
+            state.exists = true;
+            state.count = Math.min(amount, limit);
+            return Promise.resolve([{ count: state.count }]);
+        }
+        if (state.count + amount <= limit) {
+            state.count += amount;
+            return Promise.resolve([{ count: state.count }]);
+        }
+        return Promise.resolve([]);
+    });
+    const findOne = jest.fn(() => Promise.resolve(state.exists ? { count: state.count } : null));
+    return { repo: { query, findOne } as unknown as jest.Mocked<Repository<FeatureUsage>>, state };
+}
+
+function createUserCreditRepositoryMock(initialBalance = 0) {
+    const state = { balance: initialBalance };
+    const findOne = jest.fn(() => Promise.resolve({ balance: state.balance }));
+    // UPDATE...RETURNING trả về tuple [rows, rowCount], không phải rows trực tiếp.
+    const query = jest.fn((sql: string, params: unknown[]) => {
+        const [amount] = params as [number, string];
+        if (sql.includes('"balance" + $1')) {
+            state.balance += amount;
+            return Promise.resolve([[{ balance: state.balance }], 1]);
+        }
+        if (state.balance >= amount) {
+            state.balance -= amount;
+            return Promise.resolve([[{ balance: state.balance }], 1]);
+        }
+        return Promise.resolve([[], 0]);
+    });
+    return { repo: { query, findOne } as unknown as jest.Mocked<Repository<UserCredit>>, state };
+}
+
+describe("QuotaService.consumeQuota", () => {
+    it("allows at most FREE_DAILY_QUOTA_LIMIT free uses per user per day under concurrent requests", async () => {
+        const featureUsage = createFeatureUsageRepositoryMock();
+        const userCredit = createUserCreditRepositoryMock(0);
+        const service = new QuotaService(featureUsage.repo, userCredit.repo);
+
+        const attempts = FREE_DAILY_QUOTA_LIMIT + 5;
+        const results = await Promise.all(Array.from({ length: attempts }, () => service.consumeQuota("user-1")));
+
+        const allowedFree = results.filter((r) => r.allowed && r.source === "free");
+        const denied = results.filter((r) => !r.allowed);
+
+        expect(allowedFree).toHaveLength(FREE_DAILY_QUOTA_LIMIT);
+        expect(denied).toHaveLength(attempts - FREE_DAILY_QUOTA_LIMIT);
+    });
+
+    it("falls back to paid credits once free quota is exhausted, and never over-spends the balance", async () => {
+        const featureUsage = createFeatureUsageRepositoryMock(FREE_DAILY_QUOTA_LIMIT); // free already used up today
+        const userCredit = createUserCreditRepositoryMock(3);
+        const service = new QuotaService(featureUsage.repo, userCredit.repo);
+
+        const results = await Promise.all(Array.from({ length: 5 }, () => service.consumeQuota("user-1")));
+
+        const allowedPaid = results.filter((r) => r.allowed && r.source === "paid");
+        const denied = results.filter((r) => !r.allowed);
+
+        expect(allowedPaid).toHaveLength(3);
+        expect(denied).toHaveLength(2);
+        expect(userCredit.state.balance).toBe(0);
+    });
+
+    it("denies the request without side effects when both free quota and paid balance are exhausted", async () => {
+        const featureUsage = createFeatureUsageRepositoryMock(FREE_DAILY_QUOTA_LIMIT);
+        const userCredit = createUserCreditRepositoryMock(0);
+        const service = new QuotaService(featureUsage.repo, userCredit.repo);
+
+        const result = await service.consumeQuota("user-1");
+
+        expect(result).toEqual({ allowed: false });
+    });
+});
+
+describe("QuotaService.refundQuota", () => {
+    it("credits back a paid usage", async () => {
+        const featureUsage = createFeatureUsageRepositoryMock();
+        const userCredit = createUserCreditRepositoryMock(0);
+        const service = new QuotaService(featureUsage.repo, userCredit.repo);
+
+        await service.refundQuota("user-1", "paid");
+
+        expect(userCredit.state.balance).toBe(1);
+    });
+});
+
+describe("QuotaService.hasQuotaAvailable", () => {
+    it("is a non-mutating check — does not consume anything", async () => {
+        const featureUsage = createFeatureUsageRepositoryMock(FREE_DAILY_QUOTA_LIMIT - 1);
+        const userCredit = createUserCreditRepositoryMock(0);
+        const service = new QuotaService(featureUsage.repo, userCredit.repo);
+
+        await expect(service.hasQuotaAvailable("user-1")).resolves.toBe(true);
+        expect(featureUsage.state.count).toBe(FREE_DAILY_QUOTA_LIMIT - 1);
+    });
+
+    it("is true when paid credits remain after free quota is exhausted", async () => {
+        const featureUsage = createFeatureUsageRepositoryMock(FREE_DAILY_QUOTA_LIMIT);
+        const userCredit = createUserCreditRepositoryMock(1);
+        const service = new QuotaService(featureUsage.repo, userCredit.repo);
+
+        await expect(service.hasQuotaAvailable("user-1")).resolves.toBe(true);
+    });
+
+    it("is false when both free quota and paid balance are exhausted", async () => {
+        const featureUsage = createFeatureUsageRepositoryMock(FREE_DAILY_QUOTA_LIMIT);
+        const userCredit = createUserCreditRepositoryMock(0);
+        const service = new QuotaService(featureUsage.repo, userCredit.repo);
+
+        await expect(service.hasQuotaAvailable("user-1")).resolves.toBe(false);
+    });
+});

--- a/src/modules/billing/services/quota.service.ts
+++ b/src/modules/billing/services/quota.service.ts
@@ -1,0 +1,102 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { FeatureUsage } from "../entities/feature-usage.entity";
+import { UserCredit } from "../entities/user-credit.entity";
+import { QuotaConsumptionResult, QuotaStatus } from "../types/billing.types";
+
+export const FREE_DAILY_QUOTA_LIMIT = 10;
+
+// Ngày quota tính theo giờ Việt Nam (UTC+7), reset lúc 00:00 UTC+7 — không rollover.
+function getUsageDateUtc7(): string {
+    return new Date(Date.now() + 7 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+function getNextResetAtUtc7(): string {
+    const utc7Now = new Date(Date.now() + 7 * 60 * 60 * 1000);
+    const nextMidnightUtc7 = new Date(Date.UTC(utc7Now.getUTCFullYear(), utc7Now.getUTCMonth(), utc7Now.getUTCDate() + 1));
+    return new Date(nextMidnightUtc7.getTime() - 7 * 60 * 60 * 1000).toISOString();
+}
+
+@Injectable()
+export class QuotaService {
+    constructor(
+        @InjectRepository(FeatureUsage)
+        private readonly featureUsageRepository: Repository<FeatureUsage>,
+        @InjectRepository(UserCredit)
+        private readonly userCreditRepository: Repository<UserCredit>
+    ) {}
+
+    // Trừ free quota trước, hết free mới trừ paid credits. Cả hai bước atomic
+    // nhờ điều kiện WHERE ngay trong statement — Postgres tự serialize các
+    // request đồng thời cùng key qua row lock, không cần transaction Node-side.
+    async consumeQuota(userId: string, amount = 1): Promise<QuotaConsumptionResult> {
+        const usageDate = getUsageDateUtc7();
+
+        const freeRows = await this.featureUsageRepository.query<Array<{ count: number }>>(
+            `INSERT INTO feature_usage ("userId", "usageDate", "count")
+             VALUES ($1, $2, LEAST($3::integer, $4::integer))
+             ON CONFLICT ("userId", "usageDate") DO UPDATE SET "count" = feature_usage."count" + $3
+             WHERE feature_usage."count" + $3 <= $4
+             RETURNING "count"`,
+            [userId, usageDate, amount, FREE_DAILY_QUOTA_LIMIT]
+        );
+        if (freeRows.length > 0) {
+            return { allowed: true, source: "free" };
+        }
+
+        // manager.query() trên UPDATE trả về tuple [rows, rowCount] chứ không phải rows
+        // trực tiếp (khác với INSERT) — phải destructure đúng, nếu không rows.length
+        // luôn = 2 (truthy) bất kể WHERE có match hàng nào không.
+        const [paidRows] = await this.userCreditRepository.query<[Array<{ balance: number }>, number]>(
+            `UPDATE user_credits SET "balance" = "balance" - $1, "updatedAt" = NOW()
+             WHERE "userId" = $2 AND "balance" >= $1
+             RETURNING "balance"`,
+            [amount, userId]
+        );
+        if (paidRows.length > 0) {
+            return { allowed: true, source: "paid" };
+        }
+
+        return { allowed: false };
+    }
+
+    // Dùng khi handler tính năng lỗi 500 SAU KHI đã trừ quota. Với paid credits
+    // đây là bắt buộc (là tiền của user); với free chỉ để hiển thị đúng số liệu.
+    async refundQuota(userId: string, source: "free" | "paid", amount = 1): Promise<void> {
+        if (source === "free") {
+            const usageDate = getUsageDateUtc7();
+            await this.featureUsageRepository.query(`UPDATE feature_usage SET "count" = GREATEST("count" - $1, 0) WHERE "userId" = $2 AND "usageDate" = $3`, [
+                amount,
+                userId,
+                usageDate
+            ]);
+            return;
+        }
+
+        await this.userCreditRepository.query(`UPDATE user_credits SET "balance" = "balance" + $1, "updatedAt" = NOW() WHERE "userId" = $2`, [amount, userId]);
+    }
+
+    // Kiểm tra không mutate state — dùng để chặn sớm trước khi gọi AI (tránh tốn
+    // chi phí AI cho request chắc chắn bị từ chối). Việc trừ quota thật chỉ xảy ra
+    // ở consumeQuota(), gọi SAU KHI AI phản hồi thành công.
+    async hasQuotaAvailable(userId: string): Promise<boolean> {
+        const status = await this.getQuotaStatus(userId);
+        return status.freeUsed < status.freeLimit || status.paidCredits > 0;
+    }
+
+    async getQuotaStatus(userId: string): Promise<QuotaStatus> {
+        const usageDate = getUsageDateUtc7();
+        const [usage, credit] = await Promise.all([
+            this.featureUsageRepository.findOne({ where: { userId, usageDate } }),
+            this.userCreditRepository.findOne({ where: { userId } })
+        ]);
+
+        return {
+            freeUsed: usage?.count ?? 0,
+            freeLimit: FREE_DAILY_QUOTA_LIMIT,
+            paidCredits: credit?.balance ?? 0,
+            resetsAt: getNextResetAtUtc7()
+        };
+    }
+}

--- a/src/modules/billing/types/billing.types.ts
+++ b/src/modules/billing/types/billing.types.ts
@@ -34,23 +34,3 @@ export interface CompleteOrderResult {
     alreadyProcessed: boolean;
     credits?: number;
 }
-
-export interface PaymentOrderSummary {
-    id: string;
-    packageCode: string;
-    credits: number;
-    amountLamports: string;
-    network: string;
-    status: string;
-    txSignature: string | null;
-    createdAt: string;
-    expiresAt: string;
-    completedAt: string | null;
-}
-
-export interface PaymentOrderPage {
-    orders: PaymentOrderSummary[];
-    total: number;
-    page: number;
-    limit: number;
-}

--- a/src/modules/billing/types/billing.types.ts
+++ b/src/modules/billing/types/billing.types.ts
@@ -1,0 +1,56 @@
+export interface QuotaConsumptionResult {
+    allowed: boolean;
+    source?: "free" | "paid";
+}
+
+export interface QuotaStatus {
+    freeUsed: number;
+    freeLimit: number;
+    paidCredits: number;
+    resetsAt: string;
+}
+
+export interface BuiltPaymentTransaction {
+    transaction: string;
+    blockhash: string;
+    lastValidBlockHeight: number;
+}
+
+export interface CreatedPaymentOrder extends BuiltPaymentTransaction {
+    orderId: string;
+    packageCode: string;
+    credits: number;
+    amountLamports: string;
+    expiresAt: string;
+}
+
+export interface SubmitPaymentResult {
+    success: boolean;
+    creditsAdded: number;
+    alreadyProcessed: boolean;
+}
+
+export interface CompleteOrderResult {
+    alreadyProcessed: boolean;
+    credits?: number;
+}
+
+export interface PaymentOrderSummary {
+    id: string;
+    packageCode: string;
+    credits: number;
+    amountLamports: string;
+    network: string;
+    status: string;
+    txSignature: string | null;
+    createdAt: string;
+    expiresAt: string;
+    completedAt: string | null;
+}
+
+export interface PaymentOrderPage {
+    orders: PaymentOrderSummary[];
+    total: number;
+    page: number;
+    limit: number;
+}

--- a/src/modules/chat/chat.module.ts
+++ b/src/modules/chat/chat.module.ts
@@ -5,6 +5,7 @@ import { ExecutorModule } from "../../infra/executor/executor.module";
 import { LoggerModule } from "../../common/logger/logger.module";
 import { OpenAIModule } from "../../infra/openai/openai.module";
 import { VectorStoreModule } from "../../infra/vectorstore/vectorstore.module";
+import { BillingModule } from "../billing/billing.module";
 import { DiscoveryModule } from "../discovery/discovery.module";
 import { PortfolioModule } from "../portfolio/portfolio.module";
 import { TokensModule } from "../tokens/tokens.module";
@@ -38,7 +39,8 @@ import { RagDocument } from "./entities/rag-document.entity";
         WebsocketModule,
         OpenAIModule,
         VectorStoreModule,
-        ExecutorModule
+        ExecutorModule,
+        BillingModule
     ],
     providers: [ChatService, RagService, ChatGateway],
     controllers: [ChatController],

--- a/src/modules/chat/gateways/chat.gateway.ts
+++ b/src/modules/chat/gateways/chat.gateway.ts
@@ -5,6 +5,7 @@ import { WebsocketGateway } from "../../../websocket/websocket.gateway";
 import { ChatService } from "../services/chat.service";
 import { SendMessagePayload, ChatErrorPayload, ChatToolProgressPayload } from "../types/chat.types";
 import { requireCluster } from "../../../common/cluster/cluster.types";
+import { QuotaExceededException } from "../../billing/exceptions/quota-exceeded.exception";
 
 @Injectable()
 export class ChatGateway {
@@ -106,6 +107,17 @@ export class ChatGateway {
             client.emit("chat:complete", { sessionId: payload.sessionId });
             this.logger.log(`chat:message completed client=${clientKey} session=${payload.sessionId}`, ChatGateway.name);
         } catch (error) {
+            if (error instanceof QuotaExceededException) {
+                this.logger.warn(`chat:message rejected — quota exceeded client=${clientKey} session=${payload.sessionId}`, ChatGateway.name);
+                const err: ChatErrorPayload = {
+                    sessionId: payload.sessionId,
+                    code: "quota_exceeded",
+                    message: "Daily quota exceeded"
+                };
+                client.emit("chat:error", err);
+                return;
+            }
+
             const message = error instanceof Error ? error.message : "Unknown error";
             this.logger.error(
                 `chat:message handler failed client=${clientKey} session=${payload.sessionId}: ${message}`,

--- a/src/modules/chat/services/chat.service.spec.ts
+++ b/src/modules/chat/services/chat.service.spec.ts
@@ -9,6 +9,9 @@ import type { Wallet } from "../../wallets/entities/wallet.entity";
 import type { ChatMessage } from "../entities/chat-message.entity";
 import type { ChatSession } from "../entities/chat-session.entity";
 import type { RagService } from "./rag.service";
+import type { QuotaService } from "../../billing/services/quota.service";
+import { QuotaExceededException } from "../../billing/exceptions/quota-exceeded.exception";
+import type { SendMessagePayload } from "../types/chat.types";
 import { ChatService } from "./chat.service";
 
 describe("ChatService executor routing", () => {
@@ -30,6 +33,7 @@ describe("ChatService executor routing", () => {
             {} as OpenAIService,
             {} as RagService,
             circuitBreaker,
+            {} as QuotaService,
             repository,
             {} as Repository<ChatMessage>,
             {} as Repository<Wallet>
@@ -44,5 +48,94 @@ describe("ChatService executor routing", () => {
 
         expect(circuitBreaker.forCluster.mock.calls).toContainEqual(["devnet"]);
         expect(executor.getQuote.mock.calls[0]?.[0]).toBe("devnet");
+    });
+});
+
+function createChatServiceForQuotaTests(quotaService: jest.Mocked<QuotaService>, createCompletion: jest.Mock) {
+    const sessionRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: "session-1", userId: "user-1" }),
+        create: jest.fn((entity) => entity),
+        save: jest.fn().mockResolvedValue(undefined)
+    } as unknown as Repository<ChatSession>;
+
+    const messageRepo = {
+        find: jest.fn().mockResolvedValue([]),
+        create: jest.fn((entity) => entity),
+        save: jest.fn().mockResolvedValue(undefined)
+    } as unknown as Repository<ChatMessage>;
+
+    const openaiService = { createCompletion } as unknown as OpenAIService;
+    const ragService = { buildContextPrompt: jest.fn().mockResolvedValue(null) } as unknown as RagService;
+
+    return new ChatService(
+        {} as TokensService,
+        {} as DiscoveryService,
+        {} as PortfolioService,
+        openaiService,
+        ragService,
+        {} as CircuitBreaker,
+        quotaService,
+        sessionRepo,
+        messageRepo,
+        {} as Repository<Wallet>
+    );
+}
+
+function basePayload(): SendMessagePayload {
+    return {
+        cluster: "mainnet",
+        message: "hello",
+        sessionId: "session-1",
+        userId: "user-1",
+        walletAddress: "SomeWallet"
+    };
+}
+
+// Quota chỉ áp dụng cho AI chat: kiểm tra trước khi gọi LLM (tránh tốn chi phí AI
+// cho request chắc chắn bị chặn), nhưng chỉ THỰC SỰ trừ quota khi LLM phản hồi
+// thành công — không trừ nếu LLM lỗi.
+describe("ChatService quota gating", () => {
+    it("rejects with QuotaExceededException before calling the LLM when quota is unavailable", async () => {
+        const createCompletion = jest.fn();
+        const quotaService = {
+            hasQuotaAvailable: jest.fn().mockResolvedValue(false),
+            consumeQuota: jest.fn()
+        } as unknown as jest.Mocked<QuotaService>;
+        const service = createChatServiceForQuotaTests(quotaService, createCompletion);
+
+        await expect(service.sendMessage(basePayload())).rejects.toBeInstanceOf(QuotaExceededException);
+
+        expect(createCompletion).not.toHaveBeenCalled();
+        expect(quotaService.consumeQuota).not.toHaveBeenCalled();
+    });
+
+    it("consumes quota only after the LLM responds successfully", async () => {
+        const createCompletion = jest.fn().mockResolvedValue({
+            choices: [{ finish_reason: "stop", message: { content: "Hi there" } }]
+        });
+        const quotaService = {
+            hasQuotaAvailable: jest.fn().mockResolvedValue(true),
+            consumeQuota: jest.fn().mockResolvedValue({ allowed: true, source: "free" })
+        } as unknown as jest.Mocked<QuotaService>;
+        const service = createChatServiceForQuotaTests(quotaService, createCompletion);
+
+        const response = await service.sendMessage(basePayload());
+
+        expect(response.type).toBe("text");
+        expect(quotaService.consumeQuota).toHaveBeenCalledWith("user-1");
+    });
+
+    it("does not consume quota when the LLM call fails", async () => {
+        const createCompletion = jest.fn().mockRejectedValue(new Error("LLM down"));
+        const quotaService = {
+            hasQuotaAvailable: jest.fn().mockResolvedValue(true),
+            consumeQuota: jest.fn()
+        } as unknown as jest.Mocked<QuotaService>;
+        const service = createChatServiceForQuotaTests(quotaService, createCompletion);
+
+        const response = await service.sendMessage(basePayload());
+
+        expect(response.content).toContain("issue");
+        expect(quotaService.consumeQuota).not.toHaveBeenCalled();
     });
 });

--- a/src/modules/chat/services/chat.service.ts
+++ b/src/modules/chat/services/chat.service.ts
@@ -304,6 +304,8 @@ import { ChatSession as ChatSessionEntity } from "../entities/chat-session.entit
 import { ChatMessage as ChatMessageEntity } from "../entities/chat-message.entity";
 import { Wallet } from "../../wallets/entities/wallet.entity";
 import { COMMON_SYMBOLS } from "src/modules/tokens/constants/token.constant";
+import { QuotaService } from "../../billing/services/quota.service";
+import { QuotaExceededException } from "../../billing/exceptions/quota-exceeded.exception";
 
 @Injectable()
 export class ChatService {
@@ -317,6 +319,7 @@ export class ChatService {
         private readonly openaiService: OpenAIService,
         private readonly ragService: RagService,
         private readonly circuitBreaker: CircuitBreaker,
+        private readonly quotaService: QuotaService,
         @InjectRepository(ChatSessionEntity)
         private readonly sessionRepo: Repository<ChatSessionEntity>,
         @InjectRepository(ChatMessageEntity)
@@ -452,6 +455,13 @@ export class ChatService {
             throw new HttpException("Already processing a message", 429);
         }
 
+        // Quota chỉ áp dụng cho tính năng AI chat. Kiểm tra (không trừ) TRƯỚC khi gọi
+        // LLM để không tốn chi phí AI cho request chắc chắn bị chặn — quota thật chỉ
+        // bị trừ SAU KHI LLM phản hồi thành công, xem cuối khối try dưới.
+        if (payload.userId && !(await this.quotaService.hasQuotaAvailable(payload.userId))) {
+            throw new QuotaExceededException();
+        }
+
         this.logger.log(
             `Received message for session=${payload.sessionId} wallet=${payload.walletAddress ?? "none"} length=${payload.message.length}`,
             ChatService.name
@@ -480,6 +490,20 @@ export class ChatService {
                 payload.pageContext
             );
             this.logger.log(`Session ${payload.sessionId} completed: responseType=${response.type}`, ChatService.name);
+
+            // AI đã phản hồi thành công tới đây — trừ quota bây giờ. Best-effort: nếu
+            // trừ lỗi (hiếm, chỉ là race ở đúng biên giới hạn) vẫn trả response cho
+            // user vì AI đã tốn chi phí tạo ra rồi, không thể "thu hồi".
+            if (payload.userId) {
+                await this.quotaService.consumeQuota(payload.userId).catch((error: unknown) => {
+                    this.logger.error(
+                        `Failed to consume chat quota for user ${payload.userId}`,
+                        error instanceof Error ? error.stack : error,
+                        ChatService.name
+                    );
+                });
+            }
+
             return {
                 ...response,
                 sessionId: payload.sessionId

--- a/src/modules/chat/types/chat.types.ts
+++ b/src/modules/chat/types/chat.types.ts
@@ -49,7 +49,7 @@ export interface ChatStreamChunkPayload {
 
 export interface ChatErrorPayload {
     sessionId: string;
-    code: "rate_limited" | "processing" | "llm_error" | "unknown";
+    code: "rate_limited" | "processing" | "llm_error" | "quota_exceeded" | "unauthorized" | "unknown";
     message: string;
 }
 

--- a/src/redis/services/redis.service.ts
+++ b/src/redis/services/redis.service.ts
@@ -40,7 +40,9 @@ export class RedisService implements OnModuleDestroy {
         KNOWN_TOKEN: (network: string, mint: string) => `token:known:${network}:${mint}`,
         ACTIVE_TOKENS: (network: string) => `tokens:active:${network}`,
         PENDING_REGISTRATION_TOKEN: (token: string) => `auth:pending_registration:${token}`,
-        PENDING_REGISTRATION_EMAIL: (email: string) => `auth:pending_registration:email:${email.toLowerCase()}`
+        PENDING_REGISTRATION_EMAIL: (email: string) => `auth:pending_registration:email:${email.toLowerCase()}`,
+        BILLING_ORDER_RATE_LIMIT: (userId: string) => `billing:order_rate:${userId}`,
+        BILLING_RECONCILE_CURSOR: (network: string) => `billing:reconcile_cursor:${network}`
     });
 
     public static readonly TTL = redisTtls({
@@ -58,6 +60,7 @@ export class RedisService implements OnModuleDestroy {
         KNOWN_TOKEN: 24 * 60 * 60,
         PENDING_REGISTRATION_TOKEN: 24 * 60 * 60,
         PENDING_REGISTRATION_EMAIL: 24 * 60 * 60,
+        BILLING_ORDER_RATE_LIMIT: 60 * 60, // 10 đơn/giờ/user — xem PaymentService.assertOrderRateLimitNotExceeded
         OHLC_BUCKET: (interval: string) => OHLC_INTERVAL_TTLS[interval as keyof typeof OHLC_INTERVAL_TTLS] ?? 60 * 60,
         OHLC_LAST_CLOSE: (interval: string) => (OHLC_INTERVAL_TTLS[interval as keyof typeof OHLC_INTERVAL_TTLS] ?? 60 * 60) * 3
     } satisfies Partial<Record<keyof typeof RedisService.KEYS, RedisTtlValue>>);
@@ -123,6 +126,16 @@ export class RedisService implements OnModuleDestroy {
         } catch (error) {
             logError(this.logger, `Redis exists error for key "${key}"`, error);
             return false;
+        }
+    }
+
+    async incr(key: RedisKey): Promise<number | null> {
+        if (!this.redis) return null;
+        try {
+            return await this.redis.incr(key);
+        } catch (error) {
+            logError(this.logger, `Redis incr error for key "${key}"`, error);
+            return null;
         }
     }
 

--- a/src/redis/utils/redisKeys.ts
+++ b/src/redis/utils/redisKeys.ts
@@ -2,7 +2,7 @@ declare const redisKeyBrand: unique symbol;
 
 export type RedisKey = string & { readonly [redisKeyBrand]: true };
 
-type RedisKeyBuilder = (...args: unknown[]) => string;
+type RedisKeyBuilder = (...args: never[]) => string;
 type RedisKeyMap<T extends Record<string, RedisKeyBuilder>> = { [K in keyof T]: (...args: Parameters<T[K]>) => RedisKey };
 
 export const redisKeys = <T extends Record<string, RedisKeyBuilder>>(keys: T): RedisKeyMap<T> => {


### PR DESCRIPTION
Add daily free quota (10/day) for AI chat with automatic fallback to paid credits purchased via SOL transfer, plus a reconcile cron as a safety net for payments confirmed on-chain but not yet recorded.

- QuotaService: free-quota-first then paid-credit consumption, atomic via Postgres WHERE-conditioned UPSERT/UPDATE, refund on failed usage
- PaymentService: create/track SOL payment orders, idempotent completion shared between user-submit and reconcile cron
- ChatService/ChatGateway: gate quota before calling the LLM, consume only after a successful response, surface quota_exceeded to clients
- Remove the temporary hardcoded LLM completion bypass, restore the real OpenAI call